### PR TITLE
Remove GraphQL use for creation of statuses 

### DIFF
--- a/app/controllers/chatops_controller.rb
+++ b/app/controllers/chatops_controller.rb
@@ -24,22 +24,16 @@ EOS
   chatop :create_status,
   /set (?<level>red|yellow|green)(?: (?<message>(.*)))?/i,
   "set <level> <message> - Set the current status. Message is optional." do
-    level = jsonrpc_params[:level].upcase
-    message = jsonrpc_params[:message].blank? ? nil : jsonrpc_params[:message]
+    result = Statuses::CreateStatus.call(
+      level: jsonrpc_params[:level],
+      message: jsonrpc_params[:message],
+    )
 
-    data = execute_query(CreateStatusQuery, variables: { level: level, message: message })
-
-    status_result = data.create_status
-
-    if data.errors.any?
-      return jsonrpc_failure("Something went wrong: #{data.errors.messages.values.join(", ")}")
+    if result.success?
+      jsonrpc_success("Updated status: #{result.status.level.upcase} - #{result.status.message}")
+    else
+      jsonrpc_failure("Something went wrong: #{result.errors.join(", ")}")
     end
-
-    if status_result.errors.any?
-      return jsonrpc_failure("Something went wrong: #{status_result.errors.join(", ")}")
-    end
-
-    jsonrpc_success("Updated status: #{status_result.status.level} - #{status_result.status.message}")
   end
 
   CurrentStatusQuery = parse_query <<-'GRAPHQL'

--- a/app/controllers/chatops_controller.rb
+++ b/app/controllers/chatops_controller.rb
@@ -9,18 +9,6 @@ class ChatopsController < ApplicationController
 :rotating_light: Beacon – Leap's status page.
 EOS
 
-  CreateStatusQuery = parse_query <<-'GRAPHQL'
-    mutation($level: StatusLevel!, $message: String) {
-      createStatus(input: { level: $level, message: $message }) {
-        status {
-          level
-          message
-        }
-        errors
-      }
-    }
-  GRAPHQL
-
   chatop :create_status,
   /set (?<level>red|yellow|green)(?: (?<message>(.*)))?/i,
   "set <level> <message> - Set the current status. Message is optional." do

--- a/app/models/statuses/create_status.rb
+++ b/app/models/statuses/create_status.rb
@@ -16,9 +16,15 @@ module Statuses
     end
 
     def call
+      status_message = if message.blank?
+        Status.default_message_for(level)
+      else
+        message
+      end
+
       status = Status.new(
         level: level,
-        message: message || Status.default_message_for(level),
+        message: status_message,
       )
 
       if status.save

--- a/app/models/statuses/create_status.rb
+++ b/app/models/statuses/create_status.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Statuses
+  class CreateStatus
+
+    # inputs - A Hash of attributes to create a status.
+    # inputs[:level] - A String that is a `level` enum value for a Status.
+    # inputs[:message] - (optional) A String message to use for the status.
+    def self.call(inputs)
+      new(inputs).call
+    end
+
+    def initialize(level:, message: nil)
+      @level   = level
+      @message = message
+    end
+
+    def call
+      status = Status.new(
+        level: level,
+        message: message || Status.default_message_for(level),
+      )
+
+      if status.save
+        Result.success(status: status)
+      else
+        Result.failure(errors: status.errors.full_messages)
+      end
+    rescue ArgumentError => error
+      Result.failure(errors: [error.message])
+    end
+
+    private
+
+    attr_reader :level, :message
+
+    class Result
+      attr_reader :status, :success, :errors
+      alias_method :success?, :success
+
+      # status - The Status that is being created.
+      # success - A Boolean indicating if creating the status was successful.
+      # errors - An Array of any errors that occured when creating the listing.
+      def initialize(status:, success:, errors:)
+        @status  = status
+        @success = success
+        @errors  = errors
+      end
+
+      def self.success(status:)
+        new(
+          status: status,
+          success: true,
+          errors: [],
+        )
+      end
+
+      def self.failure(errors:)
+        new(
+          status: nil,
+          success: false,
+          errors: errors,
+        )
+      end
+    end
+  end
+end

--- a/lib/graph/mutations/create_status.rb
+++ b/lib/graph/mutations/create_status.rb
@@ -12,18 +12,20 @@ module Graph
       field :errors, [String], null: false
 
       def resolve(**inputs)
-        message = inputs[:message] || Status.default_message_for(inputs[:level])
-        status = Status.new(level: inputs[:level], message: message)
+        result = Statuses::CreateStatus.call(
+          level: inputs[:level],
+          message: inputs[:message],
+        )
 
-        if status.save
+        if result.success?
           {
-            status: status,
-            errors: []
+            status: result.status,
+            errors: [],
           }
         else
           {
             status: nil,
-            errors: status.errors.full_messages
+            errors: result.errors,
           }
         end
       end

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class StatusTest < ActiveSupport::TestCase

--- a/test/models/statuses/create_status_test.rb
+++ b/test/models/statuses/create_status_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Statuses::CreateStatusTest < ActiveSupport::TestCase
+  test "creates a status with default message" do
+    assert_empty Status.all
+
+    result = Statuses::CreateStatus.call(level: "green")
+
+    assert_predicate result, :success?
+    assert_empty result.errors
+    assert_equal Status.default_message_for("green"), result.status.message
+    assert_equal [result.status], Status.all
+  end
+
+  test "creates a status with custom message" do
+    assert_empty Status.all
+
+    result = Statuses::CreateStatus.call(
+      level: "green",
+      message: "Hack the planet",
+    )
+
+    assert_predicate result, :success?
+    assert_empty result.errors
+    assert_equal "Hack the planet", result.status.message
+    assert_equal [result.status], Status.all
+  end
+
+  test "returns error for invalid level value" do
+    assert_empty Status.all
+
+    result = Statuses::CreateStatus.call(
+      level: "orisa",
+      message: "Hack the planet",
+    )
+
+    refute_predicate result, :success?
+    assert_equal ["'orisa' is not a valid level"], result.errors
+    assert_empty Status.all
+  end
+
+  test "returns error for message over limit" do
+    assert_empty Status.all
+
+    message = "a" * 141
+
+    result = Statuses::CreateStatus.call(
+      level: "green",
+      message: message,
+    )
+
+    refute_predicate result, :success?
+    assert_equal ["Message is too long (maximum is 140 characters)"], result.errors
+    assert_empty Status.all
+  end
+end


### PR DESCRIPTION
This is the first part of removing graphql-client from the app.